### PR TITLE
 Allow curl to be executed on soong build

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -78,6 +78,7 @@ var Configuration = map[string]PathConfig{
 	"bc":       Allowed,
 	"bzip2":    Allowed,
 	"cpio":     Allowed,
+	"curl":     Allowed,
 	"date":     Allowed,
 	"dd":       Allowed,
 	"diff":     Allowed,


### PR DESCRIPTION
It uses by WireGuard to fetch module archive.
By default, we got our build sandboxed with zero-connection.
So, you have to set BUILD_BROKEN_USES_NETWORK := true
in your BoardConfig.mk in order to use curl properly

Signed-off-by: Nauval Rizky <enuma.alrizky@gmail.com>
Co-Authored-By: Nauval Rizky <enuma.alrizky@gmail.com>